### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Go CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/fabitee/ginutils/security/code-scanning/1](https://github.com/fabitee/ginutils/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it only needs read access to the repository contents (`contents: read`). This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
